### PR TITLE
[mod] multiple modifications

### DIFF
--- a/container/message.cpp
+++ b/container/message.cpp
@@ -7,7 +7,6 @@ Message::Message()
     m_pData = new char[MESSAGE_DEFAULT_SIZE];
     memset(m_pData, 0, MESSAGE_DEFAULT_SIZE);
     m_nSize = MESSAGE_DEFAULT_SIZE;
-    m_pTime = new Timer();
 }
 
 Message::Message(const char* pData, int nSize)
@@ -15,7 +14,6 @@ Message::Message(const char* pData, int nSize)
     m_pData = new char[nSize];
     memcpy(m_pData, pData, nSize);
     m_nSize = nSize;
-    m_pTime = new Timer();
 }
 
 Message::Message(const Message& ref)
@@ -23,17 +21,11 @@ Message::Message(const Message& ref)
     m_pData = new char[ref.size()];
     memcpy(m_pData, ref.getData(), ref.size());
     m_nSize = ref.size();
-    m_pTime = new Timer();
 }
 
 Message::~Message()
 {
     m_nSize = 0;
-    if(m_pTime)
-    {
-        delete m_pTime;
-        m_pTime = NULL;
-    }
     if(m_pData)
     {
         delete[] m_pData;

--- a/container/message.h
+++ b/container/message.h
@@ -25,7 +25,6 @@ public:
         }
         memcpy(this->m_pData, ref.m_pData, ref.size());
         this->m_nSize = ref.m_nSize;
-        this->m_pTime->resetTime();
 
         return *this;
     }
@@ -41,15 +40,9 @@ public:
         return m_nSize;
     }
 
-    inline Timer* getTime() const
-    {
-        return m_pTime;
-    }
-
 private:
     char*          m_pData;
     size_t         m_nSize;
-    Timer*         m_pTime;
 };
 USAF_END
 #endif

--- a/misc/usaf_time.h
+++ b/misc/usaf_time.h
@@ -3,6 +3,7 @@
 
 #include <time.h>
 #include <sys/time.h>
+#include <string.h>
 
 #include "../inc/usaf_base.h"
 USAF_START
@@ -52,6 +53,15 @@ public:
     void resetTime()
     {
         gettimeofday(m_pTimeVal, NULL);
+    }
+
+    void copy(Timer* pTimer)
+    {
+        if(!pTimer || !this)
+        {
+            return;
+        }
+        memcpy(m_pTimeVal, pTimer->m_pTimeVal, sizeof(timeval));
     }
     
 private:

--- a/net/accepter.cpp
+++ b/net/accepter.cpp
@@ -24,9 +24,9 @@ bool Accepter::process()
         {
             continue;
         }
-        spSessionInfo session = std::make_shared<SessionInfo>(SessionInfo());
-        session->setSession(nFd);
-        m_pFdManager->insertSession(nFd, session);
+        SessionInfo* pSession = new SessionInfo();
+        pSession->setSession(nFd);
+        m_pFdManager->insertSession(nFd, pSession);
     }
 }
 

--- a/net/container/tcp_message.cpp
+++ b/net/container/tcp_message.cpp
@@ -8,12 +8,13 @@ TCPMessage::TCPMessage()
 
 TCPMessage::TCPMessage(const TCPMessage& ref) : Message(ref)
 {
-    m_pSession = ref.m_pSession;
+    m_pSession = new SessionInfo();
+    memcpy(m_pSession, ref.m_pSession, sizeof(SessionInfo));
 }
 
-TCPMessage::TCPMessage(const char * pData, int nSize, spSessionInfo pSession):Message(pData, nSize)
+TCPMessage::TCPMessage(const char * pData, int nSize, SessionInfo* pSession):Message(pData, nSize)
 {
-    m_pSession = pSession;
+    m_pSession = new SessionInfo(pSession);
 }
 
 TCPMessage::~TCPMessage()
@@ -21,7 +22,7 @@ TCPMessage::~TCPMessage()
 
 }
 
-spSessionInfo TCPMessage::getSessionInfo()
+SessionInfo* TCPMessage::getSessionInfo()
 {
     return m_pSession;
 }

--- a/net/container/tcp_message.h
+++ b/net/container/tcp_message.h
@@ -10,14 +10,14 @@ class TCPMessage : public Message
 public:
     TCPMessage();
     TCPMessage(const TCPMessage& ref);
-    TCPMessage(const char* pData, int nSize, spSessionInfo pSession);
+    TCPMessage(const char* pData, int nSize, SessionInfo* pSession);
 
     ~TCPMessage();
 
-    spSessionInfo getSessionInfo();
+    SessionInfo*    getSessionInfo();
 
 private:
-    spSessionInfo           m_pSession;
+    SessionInfo*     m_pSession;
 };
 
 USAF_END

--- a/net/fd_manager.h
+++ b/net/fd_manager.h
@@ -3,13 +3,11 @@
 
 #include <map>
 #include <sys/epoll.h>
-#include <unistd.h>
 
 #include "../inc/usaf_base.h"
 #include "session.h"
 USAF_START
 
-typedef std::map<int,spSessionInfo> mapFds_t;
 class FDManager
 {
 public:
@@ -26,9 +24,9 @@ public:
 
     bool removeEpollEvent(int nFd, int nType);
 
-    bool insertSession (int nFd, spSessionInfo pSession);
+    bool insertSession (int nFd, SessionInfo* pSession);
 
-    spSessionInfo getSession(int nFd);
+    SessionInfo* getSession(int nFd);
 
     bool delSession(int nFd, int nType);
 
@@ -49,7 +47,7 @@ public:
 
 private:
 
-    std::map<int,spSessionInfo>             m_mpFds;
+    std::map<int,SessionInfo*>   m_mpFds;
     int                 m_EpollFdRead;
     int                 m_EpollFdWrite;
     int                 m_nEpollSize;
@@ -57,6 +55,7 @@ private:
     pthread_mutex_t      m_mutexFds;
     pthread_mutex_t      m_mutexRdFd;
     pthread_mutex_t      m_mutexWtFd;
+
 };
 
 

--- a/net/net_service.cpp
+++ b/net/net_service.cpp
@@ -175,7 +175,7 @@ bool NetService::stop()
     return true;
 }
 
-void NetService::transPort(spTcpMessage pMsg)
+void NetService::transPort(TCPMessage* pMsg)
 {
     if(!pMsg)
     {

--- a/net/net_service.h
+++ b/net/net_service.h
@@ -28,7 +28,7 @@ public:
     virtual bool start();
     virtual bool stop();
 
-    void transPort(spTcpMessage pMsg);
+    void transPort(TCPMessage* pMsg);
 
 
 protected:

--- a/net/session.h
+++ b/net/session.h
@@ -15,16 +15,30 @@ class SessionInfo
 public:
     SessionInfo()
     {
-        m_pConnTime = NULL;
+        m_nFd = 0;
+        m_nPort = 0;
+        m_pTime = new Timer();
     }
     ~SessionInfo()
     {
         m_nFd = 0;
         m_nPort = 0;
-        if(m_pConnTime)
+        if(m_pTime)
         {
-            delete m_pConnTime;
-            m_pConnTime = NULL;
+            delete m_pTime;
+            m_pTime = NULL;
+        }
+    }
+
+    SessionInfo(SessionInfo* pRef)
+    {
+        if(pRef)
+        {
+            m_nFd = pRef->m_nFd;
+            m_nPort = pRef->m_nPort;
+            m_strAddr = pRef->m_strAddr;
+            m_pTime = new Timer();
+            m_pTime->copy(pRef->m_pTime);
         }
     }
 
@@ -36,7 +50,7 @@ public:
 		getpeername(nFd, (sockaddr*)&addr, &addrLen);
 		m_strAddr = std::string(inet_ntoa(addr.sin_addr));
 		m_nPort = ntohs(addr.sin_port);
-        m_pConnTime = new Timer();
+        m_pTime->resetTime();
         m_nFd = nFd;
     }
 
@@ -55,18 +69,17 @@ public:
         return m_strAddr;
     }
 
-    Timer* getConnTime() const
+    Timer* getTimer() const
     {
-        return m_pConnTime;
+        return m_pTime;
     }
 
 private:
     int             m_nFd;
     int             m_nPort;
     std::string     m_strAddr;
-    Timer*          m_pConnTime;
+    Timer*          m_pTime;
 };
 
-typedef std::shared_ptr<SessionInfo> spSessionInfo;
 USAF_END
 #endif

--- a/net/tcp_message_queue_mgr.h
+++ b/net/tcp_message_queue_mgr.h
@@ -5,8 +5,7 @@
 #include "container/tcp_message.h"
 USAF_START
 
-typedef std::shared_ptr<TCPMessage> spTcpMessage;
-typedef MessageQueue<spTcpMessage> TcpMessageQueue;
+typedef MessageQueue<TCPMessage*> TcpMessageQueue;
 const int DEFAULT_MESSAGE_QUEUE_PROCESSER_CNT = 4;
 
 class TcpMessageQueueMgr
@@ -43,7 +42,6 @@ private:
     int                 m_nReadProcesserCnt;
     int                 m_nWriteProcesserCnt;
 };
-
 
 USAF_END
 #endif

--- a/net/tcp_processer.cpp
+++ b/net/tcp_processer.cpp
@@ -24,12 +24,16 @@ bool TcpProcesser::process()
     }
     while(isRunning())
     {
-        spTcpMessage pMsg = NULL;
+        TCPMessage* pMsg = NULL;
         if(!pMessageQueueRead->get(m_nId, pMsg))
         {
             continue;
         }
         std::cout << pMsg << std::endl;
+        if(pMsg)
+        {
+            delete pMsg;
+        }
     }
 }
 

--- a/net/tcp_recver.cpp
+++ b/net/tcp_recver.cpp
@@ -1,4 +1,5 @@
 #include "tcp_recver.h"
+#include <unistd.h>
 USAF_START
 TcpRecver::TcpRecver(FDManager* pFdManager)
 {
@@ -83,7 +84,7 @@ void TcpRecver::doRecv(epoll_event * pEvent, char * pBuffer)
              }
             continue;
         }
-        spTcpMessage pMsg = std::make_shared<TCPMessage>(TCPMessage(pBuffer, nRecvRet, m_pFdManager->getSession(nFd)));
+        TCPMessage* pMsg = new TCPMessage(pBuffer, nRecvRet, m_pFdManager->getSession(nFd));
         m_pMQ->put(nFd, pMsg);
     }//for
 }
@@ -91,6 +92,7 @@ void TcpRecver::doRecv(epoll_event * pEvent, char * pBuffer)
 void TcpRecver::disconnect(int nFd)
 {
     m_pFdManager->delSession(nFd, FDManager::EpollEventType::read_event);
+    //close(nFd);
 }
 
 USAF_END

--- a/net/tcp_recver.h
+++ b/net/tcp_recver.h
@@ -20,10 +20,10 @@ public:
     void disconnect(int nFd);
 
 private:
-    int                 m_nReadFd;              //epoll read fd
-    int                 m_nEpollSize;           //epoll list size
-    FDManager*          m_pFdManager;           //all accepted fd
-    TcpMessageQueue*    m_pMQ;          //msg queue
+    int                 m_nReadFd;
+    int                 m_nEpollSize;
+    FDManager*          m_pFdManager;
+    TcpMessageQueue*    m_pMQ;
 };
 
 #define TCPRECVER_BUFFER    10000

--- a/net/test/test.cpp
+++ b/net/test/test.cpp
@@ -1,5 +1,6 @@
 #include <thread>
 #include <string>
+#include <unistd.h>
 
 #include "../../inc/usaf_base.h"
 #include "../tcp_message_queue_mgr.h"
@@ -15,15 +16,16 @@ void func_send(void* p, int nHash)
 {
     TcpMessageQueue* pReadMq = TcpMessageQueueMgr::getInstance()->getReadMessageQueue();
     NetService* pServ = (NetService*)p;
-    spTcpMessage pRecvMsg;
+    TCPMessage* pRecvMsg;
     while(true)
     {
         if(pReadMq->get(nHash, pRecvMsg))
         {
-            std::cout << pRecvMsg->getData() << std::endl;
-            spTcpMessage pSendMsg = std::make_shared<TCPMessage>(TCPMessage(res.data(), res.size(), pRecvMsg->getSessionInfo()));
+            //std::cout << pRecvMsg->getData() << std::endl;
+            TCPMessage* pSendMsg = new TCPMessage(res.data(), res.size(), pRecvMsg->getSessionInfo());
             //pServ->transPort(pSendMsg);
-            send((*pSendMsg).getSessionInfo().get()->getFd(), pSendMsg->getData(), pSendMsg->size(), MSG_NOSIGNAL);
+            send(pSendMsg->getSessionInfo()->getFd(), pSendMsg->getData(), pSendMsg->size(), MSG_NOSIGNAL);
+            delete pRecvMsg;
         }
         else
         {


### PR DESCRIPTION
1.remove timer in message, just using session timer
2.timer class no longer  reset timer when copy constructing, now supporting a function copy() to copy timer from anothre timer object
3.fix crash when tcpmessage object in copy-constructing
4.remove shared_ptr from message queu
5.remove printing recved msg
6.add sesssion copy-constructing